### PR TITLE
Apply changes into built files to fix error on Safari 13

### DIFF
--- a/build-wasm.sh
+++ b/build-wasm.sh
@@ -7,4 +7,7 @@ cmake \
     -DCMAKE_C_FLAGS="-O3" \
     -DCMAKE_EXE_LINKER_FLAGS="-O3 -g0 --memory-init-file 0 -s NO_FILESYSTEM=1 -s 'EXPORTED_FUNCTIONS=[\"_argon2_hash\",\"_argon2_error_message\"]' -s DEMANGLE_SUPPORT=0 -s ASSERTIONS=0 -s NO_EXIT_RUNTIME=1 -s TOTAL_MEMORY=16MB -s BINARYEN_MEM_MAX=2147418112 -s WASM=1" && cmake --build .
 perl -pi -e 's/"argon2.js.mem"/null/g' dist/argon2.js
+perl -pi -e 's/$/if(typeof module!=="undefined")module.exports=Module;/' dist/argon2.js
+perl -pi -e 's/typeof Module!=="undefined"\?Module:\{};/typeof self!=="undefined"&&typeof self.Module!=="undefined"?self.Module:{};var jsModule=Module;/g' dist/argon2.js
+perl -pi -e 's/receiveInstantiatedSource\(output\)\{/receiveInstantiatedSource(output){Module=jsModule;if(typeof self!=="undefined")self.Module=Module;/g' dist/argon2.js
 uglifyjs dist/argon2.js -o dist/argon2.min.js -b beautify=false,ascii_only=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashlane/argon2-browser",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "Argon2 library compiled for browser runtime",
   "main": "./lib/argon2.js",
   "directories": {


### PR DESCRIPTION
This fix come from the original repo:
https://github.com/antelle/argon2-browser/commit/10d1f1f0b484f2bcba35435212d3786e1f11efef
https://github.com/antelle/argon2-browser/commit/a2e8de2a07efccbb0ff3e62d1abe33d93d8fd82c

It apply changes into auto-generated wrapper code to make it compatible with Safari 13.