### PR TITLE
argon2.js: fix loadScript for usage in Worker

### DIFF
--- a/lib/argon2.js
+++ b/lib/argon2.js
@@ -20,9 +20,13 @@
     var loadArgon2WrapperPromise;
     function loadScript(src) {
         return new Promise(function (resolve, reject) {
-            if (typeof importScript === 'function') {
-                importScript(src);
-                resolve();
+            if (typeof importScripts  === 'function') {
+                try {
+                  importScripts(src);
+                  resolve();
+                } catch (error) {
+                  reject(error)
+                }
             } else {
                 var el = document.createElement("script");
                 el.src = src;


### PR DESCRIPTION
A typo made it impossible to use the argon2.js file in a Worker.