### PR TITLE
fix: set higher minimum initial memory

### DIFF
--- a/lib/argon2.js
+++ b/lib/argon2.js
@@ -116,9 +116,16 @@
             var MB = 1024 * KB;
             var GB = 1024 * MB;
             var WASM_PAGE_SIZE = 64 * 1024;
+            /*
+             * Temporary fix to circumvent the impossibility
+             * to grow the amount of allocated memory dynamically
+             * in between each computation: set a higher minimum
+             * initial memory.
+             */
+            var MIN_INITIAL_MEMORY = 64 * MB / WASM_PAGE_SIZE;
 
             var totalMemory = (2 * GB - 64 * KB) / 1024 / WASM_PAGE_SIZE;
-            var initialMemory = Math.min(Math.max(Math.ceil(params.mem * 1024 / WASM_PAGE_SIZE), 256) + 256, totalMemory);
+            var initialMemory = Math.min(Math.max(Math.ceil(params.mem * 1024 / WASM_PAGE_SIZE), MIN_INITIAL_MEMORY) + 256, totalMemory);
             var wasmMemory = new WebAssembly.Memory({
                 initial: initialMemory,
                 maximum: totalMemory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashlane/argon2-browser",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "Argon2 library compiled for browser runtime",
   "main": "./lib/argon2.js",
   "directories": {


### PR DESCRIPTION
This should be a temporary fix, until we either rebuild the Emscripten
JS wrapper with the ALLOW_MEMORY_GROWTH build option set, or pull the
upstream changes and ditch this fork.