### PR TITLE
Feat: add param to let caller specify an initial memory allocation greater than params.mem

### DIFF
--- a/lib/argon2.js
+++ b/lib/argon2.js
@@ -52,6 +52,8 @@
      * @param {number} [params.hashLen=24] - desired hash length
      * @param {number} [params.parallelism=1] - desired parallelism (will be computed in parallel only for PNaCl)
      * @param {number} [params.type=0] - hash type: argon2.ArgonType.Argon2d or argon2.ArgonType.Argon2i
+     * @param {number} [params.allocateFor=params.mem] - Allocate enough memory when initializing the WASM module
+     * to manage subsequent computations with 'mem' set to 'allocateFor' without the need to reallocate, in KiB.
      * @param {string} params.asmFileUrl - asm.js script exact location
      * @param {string} params.wasmFileUrl - argon2.wasm script exact location
      * @param {string} params.argon2FileUrl - argon2.min.js script exact location
@@ -118,7 +120,8 @@
             var WASM_PAGE_SIZE = 64 * 1024;
 
             var totalMemory = (2 * GB - 64 * KB) / 1024 / WASM_PAGE_SIZE;
-            var initialMemory = Math.min(Math.max(Math.ceil(params.mem * 1024 / WASM_PAGE_SIZE), 256) + 256, totalMemory);
+            var allocateFor = Math.max(params.mem, params.allocateFor || 0)
+            var initialMemory = Math.min(Math.max(Math.ceil(allocateFor * 1024 / WASM_PAGE_SIZE), 256) + 256, totalMemory);
             var wasmMemory = new WebAssembly.Memory({
                 initial: initialMemory,
                 maximum: totalMemory

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dashlane/argon2-browser",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "description": "Argon2 library compiled for browser runtime",
   "main": "./lib/argon2.js",
   "directories": {


### PR DESCRIPTION
Add a param to let consumers set a minimum amount of WASM pages to allocate.